### PR TITLE
Added weekly digest email

### DIFF
--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,0 +1,16 @@
+class DigestMailer < ApplicationMailer
+  def weekly_digest_email(user, since)
+    since = Time.zone.parse(since)
+    @users = created_since(User, since)
+    @vendors = created_since(Vendor, since)
+    @reviews = created_since(Review, since)
+    @protips = created_since(Protip, since)
+    mail(to: user.email, subject: 'Weekly Digest')
+  end
+
+  private
+
+  def created_since(model, since)
+    model.where('created_at > ?', since)
+  end
+end

--- a/app/views/digest_mailer/weekly_digest_email.html.erb
+++ b/app/views/digest_mailer/weekly_digest_email.html.erb
@@ -1,0 +1,45 @@
+<h1>Weekly Digest</h1>
+
+<% if @users.present? %>
+  <h2>New Users</h2>
+  <ul>
+    <% for user in @users %>
+      <li>
+        <%= link_to user.full_name, user_url(user) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @vendors.present? %>
+  <h2>New Vendors</h2>
+  <ul>
+    <% for vendor in @vendors %>
+      <li>
+        <%= link_to vendor.name, vendor_url(vendor) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @reviews.present? %>
+  <h2>New Reviews</h2>
+  <ul>
+    <% for review in @reviews %>
+      <li>
+        <%= link_to "#{review.user.full_name} review of #{review.vendor.name}", review_url(review) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @protips.present? %>
+  <h2>New Protips</h2>
+  <ul>
+    <% for protip in @protips %>
+      <li>
+        <%= link_to protip.title, category_url(protip.category) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/lib/tasks/digest.rake
+++ b/lib/tasks/digest.rake
@@ -1,0 +1,8 @@
+namespace :digest do
+  task send: :environment do
+    week_ago = 1.week.ago
+    User.all.find_each do |user|
+      DigestMailer.weekly_digest_email(user, week_ago.to_s).deliver_later
+    end
+  end
+end

--- a/spec/mailers/previews/digest_mailer_preview.rb
+++ b/spec/mailers/previews/digest_mailer_preview.rb
@@ -1,0 +1,5 @@
+class DigestMailerPreview < ActionMailer::Preview
+  def weekly_digest_email
+    DigestMailer.weekly_digest_email(User.first, 1.week.ago.to_s)
+  end
+end


### PR DESCRIPTION
Resolves #239 

Should be scheduled to run weekly via `bundle exec rake digest:send`.